### PR TITLE
feat: minimal output for projection shard status

### DIFF
--- a/src/AssociationRegistry.Admin.Api/ProjectieBeheer/ProjectionHostController.cs
+++ b/src/AssociationRegistry.Admin.Api/ProjectieBeheer/ProjectionHostController.cs
@@ -6,6 +6,7 @@ using Infrastructure;
 using Infrastructure.HttpClients;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ResponseModels;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -136,8 +137,13 @@ public class ProjectionController : ApiController
     private async Task<IActionResult> OkObjectOrForwardedResponse(CancellationToken cancellationToken, HttpResponseMessage response)
     {
         if (response.IsSuccessStatusCode)
-            return new OkObjectResult(
-                await response.Content.ReadFromJsonAsync<ProjectionStatus[]>(_jsonSerializerOptions, cancellationToken));
+        {
+            var result = await response.Content.ReadFromJsonAsync<ProjectionStatus[]>(_jsonSerializerOptions, cancellationToken);
+
+            return result is not null
+                ? new OkObjectResult(new MinimalProjectionStatusResponse(result))
+                : new EmptyResult();
+        }
 
         return Problem(
             title: response.ReasonPhrase,

--- a/src/AssociationRegistry.Admin.Api/ProjectieBeheer/ResponseModels/MinimalProjectionStatus.cs
+++ b/src/AssociationRegistry.Admin.Api/ProjectieBeheer/ResponseModels/MinimalProjectionStatus.cs
@@ -1,0 +1,37 @@
+﻿namespace AssociationRegistry.Admin.Api.ProjectieBeheer.ResponseModels;
+
+using Amazon.DynamoDBv2.Model;
+using Infrastructure;
+using System.Text.Json.Serialization;
+
+public record MinimalProjectionStatusResponse
+{
+    [JsonPropertyOrder(0)]
+    public long HighWaterMark { get; init; }
+
+    [JsonPropertyOrder(1)]
+    public IReadOnlyDictionary<string, long> Status { get; init; }
+
+    [JsonPropertyOrder(2)]
+    public DateTimeOffset Timestamp { get; init; }
+
+    public MinimalProjectionStatusResponse(ProjectionStatus[] projectionStatus)
+    {
+        var highWaterMarkShard = projectionStatus.Single(s => s.ShardName.Equals("HighWaterMark"));
+
+        HighWaterMark = highWaterMarkShard.Sequence;
+        Timestamp = highWaterMarkShard.Timestamp;
+
+        var status = projectionStatus
+                    .Where(w => !w.ShardName.Equals("HighWaterMark"))
+                    .Select(s => new MinimalProjectionStatus(s.ShardName, s.Sequence))
+                    .OrderBy(o => o.ShardName);
+
+        Status = status.ToDictionary(k => k.ShardName, v => v.Sequence);
+    }
+
+    public record MinimalProjectionStatus(string FullShardName, long Sequence)
+    {
+        public string ShardName { get; init; } = FullShardName.Split('.').Last().Replace(":All", "");
+    }
+}


### PR DESCRIPTION
Response from projection status endpoint is always different and slow to read. I propose we can simply that output a little:

```json
{
    "highWaterMark": 53,
    "status": {
        "beheerKboSyncHistoriekProjection": 53,
        "beheerVerenigingDetailMultiDocument": 53,
        "beheerVerenigingDetailProjection": 53,
        "beheerVerenigingHistoriekProjection": 53,
        "beheerVerenigingZoekenDocument": 53,
        "duplicateDetection": 53,
        "locatieLookupDocument": 53,
        "publiekVerenigingDetailProjection": 53,
        "publiekVerenigingZoekenDocument": 53,
        "verenigingenPerInszProjection": 53
    },
    "timestamp": "2024-07-10T13:39:01.8180436+00:00"
}
```

instead of the very lengthy and unsorted direct Marten response

```json
[
    {
        "timestamp": "2024-07-10T13:42:39.3909649+00:00",
        "shardName": "HighWaterMark",
        "sequence": 53665,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909665+00:00",
        "shardName": "AssociationRegistry.Acm.Api.Projections.VerenigingenPerInszProjection:All",
        "sequence": 53665,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909671+00:00",
        "shardName": "LocatieLookupDocument:All",
        "sequence": 53665,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909676+00:00",
        "shardName": "AssociationRegistry.Admin.ProjectionHost.Projections.KboSync.BeheerKboSyncHistoriekProjection:All",
        "sequence": 53665,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909682+00:00",
        "shardName": "BeheerVerenigingDetailMultiDocument:All",
        "sequence": 53665,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909692+00:00",
        "shardName": "AssociationRegistry.Public.ProjectionHost.Projections.Detail.PubliekVerenigingDetailProjection:All",
        "sequence": 34074,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909697+00:00",
        "shardName": "PubliekVerenigingZoekenDocument:All",
        "sequence": 34074,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909701+00:00",
        "shardName": "AssociationRegistry.Admin.ProjectionHost.Projections.Historiek.BeheerVerenigingHistoriekProjection:All",
        "sequence": 40471,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909706+00:00",
        "shardName": "AssociationRegistry.Admin.ProjectionHost.Projections.Detail.BeheerVerenigingDetailProjection:All",
        "sequence": 40471,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909712+00:00",
        "shardName": "DuplicateDetection:All",
        "sequence": 40471,
        "exception": null
    },
    {
        "timestamp": "2024-07-10T13:42:39.3909717+00:00",
        "shardName": "BeheerVerenigingZoekenDocument:All",
        "sequence": 40471,
        "exception": null
    }
]
```
