### PR TITLE
chore(release): 8.245.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [8.245.0](https://github.com/informatievlaanderen/association-registry/compare/v8.244.0...v8.245.0) (2025-06-05)
+
+
+### Bug Fixes
+
+* remove api swagger docs from public get all ([1ab511f](https://github.com/informatievlaanderen/association-registry/commit/1ab511fd9b7000ac6a6ae571553a8a887e22c179))
+
+
+### Features
+
+* or-2854 add swagger docs for searching on geotags ([fb5879b](https://github.com/informatievlaanderen/association-registry/commit/fb5879b40f6471ec479948210e45fe43d40753ce))
+
 # [8.244.0](https://github.com/informatievlaanderen/association-registry/compare/v8.243.0...v8.244.0) (2025-06-04)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "association-registry",
-  "version": "8.244.0",
+  "version": "8.245.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "association-registry",
-      "version": "8.244.0",
+      "version": "8.245.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@commitlint/cli": "17.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "association-registry",
-  "version": "8.244.0",
+  "version": "8.245.0",
   "description": "Association registry.",
   "author": "Basisregisters Vlaanderen",
   "license": "EUPL-1.2",

--- a/src/AssociationRegistry.Admin.Schema/Search/VerenigingZoekDocumentMapping.cs
+++ b/src/AssociationRegistry.Admin.Schema/Search/VerenigingZoekDocumentMapping.cs
@@ -31,7 +31,8 @@ public static class VerenigingZoekDocumentMapping
                          .Text(
                               propertyDescriptor => propertyDescriptor
                                                    .Name(document => document.Roepnaam)
-                                                   .WithKeyword(BeheerZoekenNormalizer))
+                                                   .WithKeyword(BeheerZoekenNormalizer)
+                                                   .Analyzer(BeheerZoekenAnalyzer))
                          .Date(
                               propertyDescriptor => propertyDescriptor
                                  .Name(document => document.Startdatum))

--- a/test/AssociationRegistry.Test.Admin.Api/Queries/BeheerVerenigingZoekQuery/Bugfix_RoepnaamNaGeotagsAnalyzer.cs
+++ b/test/AssociationRegistry.Test.Admin.Api/Queries/BeheerVerenigingZoekQuery/Bugfix_RoepnaamNaGeotagsAnalyzer.cs
@@ -1,0 +1,73 @@
+namespace AssociationRegistry.Test.Admin.Api.Queries.BeheerVerenigingZoekQuery;
+
+using AssociationRegistry.Admin.Api.Queries;
+using AssociationRegistry.Admin.Api.Verenigingen.Search.RequestModels;
+using AssociationRegistry.Admin.Schema.Search;
+using AutoFixture;
+using Common.AutoFixture;
+using FluentAssertions;
+using Nest;
+using Vereniging;
+using When_Saving_A_Document_To_Elastic;
+using When_Searching_On_Geotags;
+using Xunit;
+
+    //
+public class Bugfix_RoepnaamNaGeotagsAnalyzerFixture : ElasticRepositoryFixture
+{
+    public Bugfix_RoepnaamNaGeotagsAnalyzerFixture() : base(nameof(Bugfix_RoepnaamNaGeotagsAnalyzerFixture))
+    {
+
+    }
+}
+
+public class Bugfix_RoepnaamNaGeotagsAnalyzer : IClassFixture<Bugfix_RoepnaamNaGeotagsAnalyzerFixture>, IDisposable, IAsyncDisposable
+{
+    private readonly Bugfix_RoepnaamNaGeotagsAnalyzerFixture _fixture;
+    private readonly ITestOutputHelper _helper;
+    private readonly IElasticClient? _elasticClient;
+    private readonly Fixture _autoFixture;
+    private readonly BeheerVerenigingenZoekQuery _query;
+    private const string _roepnaam = "Roepnaam Et velit totam numquam voluptatibus quam ratione.2025-06-06T11:42:23.689Z";
+
+    public Bugfix_RoepnaamNaGeotagsAnalyzer(Bugfix_RoepnaamNaGeotagsAnalyzerFixture fixture, ITestOutputHelper helper)
+    {
+        _fixture = fixture;
+        _helper = helper;
+        _elasticClient = fixture.ElasticClient;
+        _autoFixture = new Fixture().CustomizeAdminApi();
+
+        _query = new BeheerVerenigingenZoekQuery(fixture.ElasticClient, fixture.TypeMapping);
+    }
+
+    [Fact]
+    public async ValueTask When_Searching_On_Roepnaam_Then_Returns_Vereniging()
+    {
+        var verenigingZoekDocument = new VerenigingZoekDocument()
+        {
+            VCode = _autoFixture.Create<VCode>(),
+            Roepnaam = _roepnaam,
+        };
+
+        await _elasticClient!.IndexDocumentAsync(verenigingZoekDocument);
+        await _elasticClient.Indices.RefreshAsync(Indices.All);
+
+        var searchResponse = await _query.ExecuteAsync(new BeheerVerenigingenZoekFilter($"vCode:{verenigingZoekDocument.VCode}", null, new PaginationQueryParams()), CancellationToken.None);
+
+        searchResponse.Documents.Should().NotBeEmpty();
+
+        searchResponse = await _query.ExecuteAsync(new BeheerVerenigingenZoekFilter($"roepnaam:\"{_roepnaam}\"", null, new PaginationQueryParams()), CancellationToken.None);
+
+        searchResponse.Documents.Should().NotBeEmpty();
+    }
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+}

--- a/test/AssociationRegistry.Test.Public.Api/Queries/PubliekVerenigingenZoekQuery/Bugfix_RoepnaamNaGeotagsAnalyzer.cs
+++ b/test/AssociationRegistry.Test.Public.Api/Queries/PubliekVerenigingenZoekQuery/Bugfix_RoepnaamNaGeotagsAnalyzer.cs
@@ -1,0 +1,80 @@
+namespace AssociationRegistry.Test.Public.Api.Queries;
+
+using AssociationRegistry.Public.Api.Queries;
+using AssociationRegistry.Public.Api.Verenigingen.Search.RequestModels;
+using AssociationRegistry.Public.Schema.Search;
+using AssociationRegistry.Test.Common.AutoFixture;
+using AssociationRegistry.Test.Public.Api.When_Saving_A_Document_To_Elastic;
+using AssociationRegistry.Vereniging;
+using AutoFixture;
+using FluentAssertions;
+using Framework;
+using Humanizer;
+using Nest;
+using Xunit;
+
+//
+public class Bugfix_RoepnaamNaGeotagsAnalyzerFixture : ElasticRepositoryFixture
+{
+    public Bugfix_RoepnaamNaGeotagsAnalyzerFixture() : base(nameof(Bugfix_RoepnaamNaGeotagsAnalyzerFixture))
+    {
+
+    }
+}
+
+public class Bugfix_RoepnaamNaGeotagsAnalyzer : IClassFixture<Bugfix_RoepnaamNaGeotagsAnalyzerFixture>, IDisposable, IAsyncDisposable
+{
+    private readonly Bugfix_RoepnaamNaGeotagsAnalyzerFixture _fixture;
+    private readonly ITestOutputHelper _helper;
+    private readonly IElasticClient? _elasticClient;
+    private readonly Fixture _autoFixture;
+    private readonly AssociationRegistry.Public.Api.Queries.PubliekVerenigingenZoekQuery _query;
+    private const string _roepnaam = "Roepnaam Et velit totam numquam voluptatibus quam ratione.2025-06-06T11:42:23.689Z";
+
+    public Bugfix_RoepnaamNaGeotagsAnalyzer(Bugfix_RoepnaamNaGeotagsAnalyzerFixture fixture, ITestOutputHelper helper)
+    {
+        _fixture = fixture;
+        _helper = helper;
+        _elasticClient = fixture.ElasticClient;
+        _autoFixture = new Fixture().CustomizePublicApi();
+
+        _query = new AssociationRegistry.Public.Api.Queries.PubliekVerenigingenZoekQuery(fixture.ElasticClient, fixture.TypeMapping);
+    }
+
+    [Fact]
+    public async ValueTask When_Searching_On_Roepnaam_Then_Returns_Vereniging()
+    {
+        var verenigingZoekDocument = new VerenigingZoekDocument()
+        {
+            VCode = _autoFixture.Create<VCode>(),
+            Roepnaam = _roepnaam,
+            IsUitgeschrevenUitPubliekeDatastroom = false,
+            IsVerwijderd = false,
+            IsDubbel = false,
+            Status = VerenigingStatus.Actief.StatusNaam
+        };
+
+        await _elasticClient!.IndexDocumentAsync(verenigingZoekDocument);
+        await _elasticClient.Indices.RefreshAsync(Indices.All);
+
+        await Task.Delay(3.Seconds());
+
+        var searchResponse = await _query.ExecuteAsync(new PubliekVerenigingenZoekFilter($"*", null, [], new PaginationQueryParams()), CancellationToken.None);
+
+        searchResponse.Documents.Should().NotBeEmpty();
+
+        searchResponse = await _query.ExecuteAsync(new PubliekVerenigingenZoekFilter($"roepnaam:\"{_roepnaam}\"", null, [], new PaginationQueryParams()), CancellationToken.None);
+
+        searchResponse.Documents.Should().NotBeEmpty();
+    }
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+}


### PR DESCRIPTION
# [8.245.0](https://github.com/informatievlaanderen/association-registry/compare/v8.244.0...v8.245.0) (2025-06-05)

### Bug Fixes

* remove api swagger docs from public get all ([1ab511f](https://github.com/informatievlaanderen/association-registry/commit/1ab511fd9b7000ac6a6ae571553a8a887e22c179))

### Features

* or-2854 add swagger docs for searching on geotags ([fb5879b](https://github.com/informatievlaanderen/association-registry/commit/fb5879b40f6471ec479948210e45fe43d40753ce))